### PR TITLE
Fix keyboard mapping for `\|` key

### DIFF
--- a/MIPS Emulator.GUI/keyboard.ini
+++ b/MIPS Emulator.GUI/keyboard.ini
@@ -306,7 +306,7 @@
 149=84
 
 ; Windows 2000: For the US standard keyboard, the '\|' key 
-154=93
+150=93
 
 ; Windows 2000: For the US standard keyboard, the ']}' key 
 151=91


### PR DESCRIPTION
Should fix #44 